### PR TITLE
Prototype: register version on release (push model)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,3 +64,14 @@ jobs:
             k6-*
             checksums.txt
           generate_release_notes: true
+
+  register-version:
+    needs: [release]
+    if: startsWith(github.ref, 'refs/tags/v')
+    uses: grafana/k6-extension-registry/.github/workflows/register-version.yml@main
+    with:
+      module: github.com/grafana/xk6-docs
+      version: ${{ github.ref_name }}
+    secrets:
+      app_id: ${{ secrets.REGISTRY_APP_ID }}
+      app_pem: ${{ secrets.REGISTRY_APP_PEM }}


### PR DESCRIPTION
Prototype for proposal 1 in grafana/k6-extension-registry#199. Adds a job to the release workflow that calls the registry's `register-version.yml` after tagging.