### PR TITLE
Pin actions to commit SHAs and scope permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,12 +9,12 @@ jobs:
   lint-test-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: '~1.25'
       - name: Lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa # v7
         with:
           version: v2.10.1
       - name: Test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,7 @@ on:
       - 'v[0-9]+.[0-9]+.[0-9]+'
   workflow_dispatch:
 
-permissions:
-  contents: write
+permissions: {}
 
 jobs:
   build:
@@ -26,10 +25,11 @@ jobs:
             goarch: amd64
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: '~1.25'
+          cache: false
       - name: Install xk6
         run: go install go.k6.io/xk6/cmd/xk6@latest
       - name: Build
@@ -42,7 +42,7 @@ jobs:
           if [ "$GOOS" = "windows" ]; then EXT=".exe"; fi
           xk6 build --output "k6-${GOOS}-${GOARCH}${EXT}" \
             --with github.com/grafana/xk6-docs=.
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: k6-${{ matrix.goos }}-${{ matrix.goarch }}
           path: k6-${{ matrix.goos }}-${{ matrix.goarch }}*
@@ -50,13 +50,15 @@ jobs:
   release:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           merge-multiple: true
       - name: Generate checksums
         run: sha256sum k6-* > checksums.txt
-      - uses: softprops/action-gh-release@v2
+      - uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:
           files: |
             k6-*


### PR DESCRIPTION
Fixes 4 zizmor findings:

- `unpinned-uses`: `golangci/golangci-lint-action@v7`, `softprops/action-gh-release@v2`, `actions/checkout@v4`, `actions/setup-go@v5`, `actions/upload-artifact@v4`, `actions/download-artifact@v4`
- `excessive-permissions`: `contents: write` at workflow level in release.yml (moved to release job)
- `cache-poisoning`: `actions/setup-go` default caching in release workflow (disabled)