### PR TITLE
Fix release CI toolchain mismatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: '~1.26'
+          go-version: 1.25.x
       - uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9
         with:
           version: v2.10.1
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: '~1.26'
+          go-version: 1.25.x
       - run: go test -race -count=1 ./...
 
   build:
@@ -32,6 +32,6 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: '~1.26'
+          go-version: 1.25.x
       - run: go install go.k6.io/xk6/cmd/xk6@latest
       - run: xk6 build --verbose --with github.com/grafana/xk6-docs=.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: '~1.25'
+          go-version: 1.25.x
           cache: false
       - name: Install xk6
         run: go install go.k6.io/xk6/cmd/xk6@latest

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/grafana/xk6-docs
 
 go 1.25.0
 
-toolchain go1.26.2
-
 require (
 	github.com/charmbracelet/glamour v1.0.0
 	github.com/creack/pty v1.1.24


### PR DESCRIPTION
Drop `toolchain go1.26.2` from go.mod. It caused k6foundry's temp module to hit `version go1.26.2 does not match go tool version go1.25.x` because cached artifacts used 1.26.2 while the build ran with 1.25.x.

Align all workflows to `go 1.25.x`, matching xk6-dns and other extensions.