### PR TITLE
sync: grant permissions to publish doc bundles

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -5,9 +5,13 @@ on:
     - cron: '3 */3 * * *'
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   sync:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0


### PR DESCRIPTION
## What?

Restores automatic publishing of documentation bundles from the sync workflow.

## Why?

New k6 versions get their doc bundle built and uploaded automatically. [The upload started failing with an HTTP 403](https://github.com/grafana/xk6-docs/actions/runs/28591283215/job/84775218029), so bundles for newer versions never made it to the release and users hit a 404 when fetching them.

The sync job carried no permissions of its own and fell back to a read-only token, which can't upload release assets. It now declares the same least-privilege permissions `release.yml` already uses: deny everything by default, grant write access to release contents only where the upload happens.
