### PR TITLE
Fix doc lookup for pages with uppercase names

### DIFF
--- a/docs/index.go
+++ b/docs/index.go
@@ -8,23 +8,26 @@ import (
 
 func (idx *Index) ensureMaps() {
 	idx.initOnce.Do(func() {
+		// Keys are lower-cased so lookups are case-insensitive, matching
+		// slugs that contain uppercase letters (e.g. jslib method names).
 		bySlug := make(map[string]*Section, len(idx.Sections))
 		for i := range idx.Sections {
-			bySlug[idx.Sections[i].Slug] = &idx.Sections[i]
+			bySlug[strings.ToLower(idx.Sections[i].Slug)] = &idx.Sections[i]
 		}
 
 		byAlias := make(map[string]*Section)
 		for i := range idx.Sections {
 			sec := &idx.Sections[i]
 			for _, a := range sec.Aliases {
+				key := strings.ToLower(a)
 				// Exact slug always wins over alias.
-				if _, taken := bySlug[a]; taken {
+				if _, taken := bySlug[key]; taken {
 					continue
 				}
-				if _, dup := byAlias[a]; dup {
+				if _, dup := byAlias[key]; dup {
 					continue
 				}
-				byAlias[a] = sec
+				byAlias[key] = sec
 			}
 		}
 
@@ -52,13 +55,13 @@ func (idx *Index) Lookup(slug string) (*Section, bool) {
 // Returns nil if slug is unknown.
 func (idx *Index) Children(slug string) []*Section {
 	idx.ensureMaps()
-	parent, ok := idx.bySlug[slug]
+	parent, ok := idx.bySlug[strings.ToLower(slug)]
 	if !ok {
 		return nil
 	}
 	out := make([]*Section, 0, len(parent.Children))
 	for _, child := range parent.Children {
-		if c, ok := idx.bySlug[child]; ok {
+		if c, ok := idx.bySlug[strings.ToLower(child)]; ok {
 			out = append(out, c)
 		}
 	}
@@ -167,7 +170,7 @@ func (idx *Index) Tree(rootSlug string, depth int) iter.Seq2[int, *Tree] {
 			roots = idx.TopLevel()
 		} else {
 			idx.ensureMaps()
-			if _, ok := idx.bySlug[rootSlug]; !ok {
+			if _, ok := idx.bySlug[strings.ToLower(rootSlug)]; !ok {
 				return
 			}
 			roots = idx.Children(rootSlug)

--- a/docs/index_test.go
+++ b/docs/index_test.go
@@ -1,0 +1,43 @@
+package docs
+
+import "testing"
+
+// Lookup is documented as case-insensitive. Slugs that contain uppercase
+// letters (e.g. jslib method names like getShardIterator) must resolve both
+// when queried exactly as stored and when queried in lower case.
+func TestLookup_CaseInsensitiveForUppercaseSlug(t *testing.T) {
+	t.Parallel()
+
+	idx := &Index{Sections: []Section{
+		{Slug: "javascript-api/jslib/aws/kinesisclient/getShardIterator", Title: "getShardIterator"},
+	}}
+
+	for _, q := range []string{
+		"javascript-api/jslib/aws/kinesisclient/getShardIterator", // exact case
+		"javascript-api/jslib/aws/kinesisclient/getsharditerator", // lower case
+	} {
+		if _, ok := idx.Lookup(q); !ok {
+			t.Errorf("Lookup(%q) = not found, want found", q)
+		}
+	}
+}
+
+// Children resolves child slugs through the same map, so uppercase child
+// slugs must be returned rather than silently skipped.
+func TestChildren_ResolvesUppercaseChildSlug(t *testing.T) {
+	t.Parallel()
+
+	idx := &Index{Sections: []Section{
+		{
+			Slug:     "javascript-api/jslib/aws/kinesisclient",
+			Title:    "kinesisclient",
+			Children: []string{"javascript-api/jslib/aws/kinesisclient/getShardIterator"},
+		},
+		{Slug: "javascript-api/jslib/aws/kinesisclient/getShardIterator", Title: "getShardIterator"},
+	}}
+
+	got := idx.Children("javascript-api/jslib/aws/kinesisclient")
+	if len(got) != 1 {
+		t.Fatalf("Children() returned %d sections, want 1", len(got))
+	}
+}


### PR DESCRIPTION
## What?

Fixes a case mismatch issue in topic retrieval.

## Why?

Reference pages like the `jslib` client methods (for example `getShardIterator`) shipped in the docs bundle but could not be opened by their path, so `k6 x docs` reported them as missing even though the content was there. Around 78 pages were unreachable this way. They now resolve, and lookups stay case-insensitive as documented, for both exact and lower-case paths.

## How to reproduce

`k6 x docs javascript-api/jslib/aws/kinesisclient/getShardIterator` returned "topic not found" before and now renders the page. The added tests cover the case-insensitive contract.
